### PR TITLE
Remove \author and \date doxygen markup.

### DIFF
--- a/sonic/std_ip_utils.h
+++ b/sonic/std_ip_utils.h
@@ -21,7 +21,6 @@
 /*!
  * \file   std_ip_utils.h
  * \brief  Ip address utility functions
- * \date   05-2014
  */
 
 #ifndef __STD_IP_UTILS_H

--- a/sonic/std_llist.h
+++ b/sonic/std_llist.h
@@ -21,7 +21,6 @@
 /*!
  * \file   std_llist.h
  * \brief  Linked list functionality
- * \date   05-2014
  */
 
 #ifndef _LLIST_H_

--- a/sonic/std_mergesort.h
+++ b/sonic/std_mergesort.h
@@ -22,7 +22,6 @@
  * \file   std_mergesort.h
  * \brief   This header file contains header file definitions Merge Sort
  *          library functions
- * \date   05-2014
  */
 
 #ifndef __STD_MERGE_SORT_H__

--- a/sonic/std_radical.h
+++ b/sonic/std_radical.h
@@ -21,7 +21,6 @@
 /*!
  * \file   std_radical.h
  * \brief  Radical Change List implementation.
- * \date   05-2014
  */
 
 #ifndef _RADICAL_H_

--- a/sonic/std_radix.h
+++ b/sonic/std_radix.h
@@ -21,7 +21,6 @@
 /*!
  * \file   std_radix.h
  * \brief  Radix tree implementation with Radical CL support
- * \date   05-2014
  */
 
 #ifndef _RADIX_H_

--- a/sonic/std_rbtree.h
+++ b/sonic/std_rbtree.h
@@ -21,7 +21,6 @@
 /*!
  * \file   std_rbtree.h
  * \brief  Red-Black tree implementation.
- * \date   05-2014
  */
 
 #ifndef _RBTREE_H_

--- a/sonic/std_type_defs.h
+++ b/sonic/std_type_defs.h
@@ -28,7 +28,6 @@
  *!
  * \file   std_type_defs.h
  * \brief  common definitions
- * \date   04-2014
  */
 
 #ifndef _STD_TYPE_DEFS_H_

--- a/sonic/std_utils.h
+++ b/sonic/std_utils.h
@@ -24,7 +24,6 @@
 /*!
  * \file   std_utils.h
  * \brief  Common utility functions
- * \date   4-2014
  */
 
 #include <string.h>

--- a/sonic/std_xml_parser.h
+++ b/sonic/std_xml_parser.h
@@ -23,7 +23,6 @@
  * \brief  XML Parser wrapper routines for parsing xml files.
  * The APIs are modelled in the line of libxml2 just to facility easy
  * development for those who are familiar with libxml2 library.
- * \date   01-2015
  */
 
 #ifndef _STD_XML_PARSER_H

--- a/src/std_ip_utils.c
+++ b/src/std_ip_utils.c
@@ -21,8 +21,6 @@
 /*!
  * \file   std_ip_utils.c
  * \brief  Ip address utility functions
- * \date   06-2014
- * \author Prince Sunny/Satish Mynam
  */
 #include <stdio.h>
 #include <string.h>

--- a/src/std_llist.c
+++ b/src/std_llist.c
@@ -21,8 +21,6 @@
 /*!
  * \file   std_llist.h
  * \brief  Linked list functionality
- * \date   05-2014
- * \author
  */
 
 #include <assert.h>

--- a/src/std_radical.c
+++ b/src/std_radical.c
@@ -21,7 +21,6 @@
 /*!
  * \file   std_radical.c
  * \brief  RADIx tree with ChAnge List (RADICAL)
- * \date   05-2014
  */
 
 /*---------------------------------------------------------------*\

--- a/src/std_radix.c
+++ b/src/std_radix.c
@@ -22,8 +22,6 @@
  * \file   std_radix.c
  * \brief  Radix tree implementation. This implementation of Radix tree is adapted
  *         from the GateD code (rt_radix.c)
- * \date   05-2014
- * \author Prince Sunny
  */
 
 /*---------------------------------------------------------------*\

--- a/src/std_rbtree.c
+++ b/src/std_rbtree.c
@@ -21,7 +21,6 @@
 /*!
  * \file   std_rbtree.c
  * \brief  Red-Black tree implementation.
- * \date   05-2014
  */
 
 

--- a/src/std_string_utils.cpp
+++ b/src/std_string_utils.cpp
@@ -21,7 +21,6 @@
 /*!
  * \file   std_utils.c
  * \brief  Common utility functions
- * \date   May-2014
  */
 
 #include "std_utils.h"

--- a/src/unit_test/std_shlib_test_lib.c
+++ b/src/unit_test/std_shlib_test_lib.c
@@ -16,9 +16,6 @@
 
 /**
  * \file std_shlib_test_lib.c
- * \brief
- *
- * \date: Oct 29, 2014
  */
 
 #include <stdio.h>


### PR DESCRIPTION
As per new policy.