### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+ACLOCAL_AMFLAGS=-I m4
 
 #The logging library
 lib_LTLIBRARIES = libsonic_common.la

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_PREREQ([2.69])
 AC_INIT([sonic-common-utils], [1.0.1], [sonicproject@gmail.com])
 
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.